### PR TITLE
add online courses for math prob and stats

### DIFF
--- a/book/contents/mathematics.md
+++ b/book/contents/mathematics.md
@@ -1,5 +1,7 @@
 # Mathematics
 
+The math and civil engineering faculties at TU Delft offer several online courses in mathematics, probability and statistics, which are described at the bottom of this page.
+
 The following topics on **Mathematics** are considered prerequisite knowledge for the civil engineering MSc-program:
 
 |Topic category|Topic   |Taught in Delft in  | Open Educational Resources[^1] |
@@ -20,7 +22,7 @@ The following topics on **Mathematics** are considered prerequisite knowledge fo
 |                      | Solving systems of linear equations                                                                                                                                          |                                 |
 |                      | Matrix algebra (sum, product, inverse, transpose)                                                                                                                                         |                                 |
 |                      | Inner products                                                                                                                                          |                                 |
-|Probability & Statistics        | Basic continuous probability distributions (Gaussian, binomial, exponential, uniform), cumulative distribution function                                                                                                                                         |[CTB2200](https://studiegids.tudelft.nl/a101_displayCourse.do?course_id=61196);  [AESB2440](https://studiegids.tudelft.nl/a101_displayCourse.do?course_id=62089)                                 |
+|Probability & Statistics        | Basic continuous probability distributions (Gaussian, binomial, exponential, uniform), cumulative distribution function                                                                                                                                         |[CTB2200](https://studiegids.tudelft.nl/a101_displayCourse.do?course_id=61196);  [AESB2440](https://studiegids.tudelft.nl/a101_displayCourse.do?course_id=62089)                                 | Online courses from EWI and CEG (see below)
 |                      | Perform computations with discrete and continuous random variables                                                                                                                                         |                                 |
 |                      | Set theory                                                                                                                                        |                                 |
 |                      | Fundamental probability rules : conditional probability, independence, total probability, Bayes’ rule                                                                                                                                         |                                 |
@@ -41,4 +43,17 @@ The following topics on **Mathematics** are considered prerequisite knowledge fo
 |                      | Combine a finite difference method with a numerical time-integration method                                                                                                                                         |                                 | 
 |                      | Select appropriate numerical methods                                                                                                                                         |                                 | 
                            
+## Online Courses at TU Delft
+
+The course [Probability and Statistics Applications for Civil Engineers](https://tudelft-citg.github.io/learn-probability/) is completely self-paced and accessible directly in your web browser. This course is meant to be a refresher for probability and statistics topics from a BSc program, not a substitute. It uses practical applications from civil engineering and related fields to illustrate key topics. More material will be added to this course by summer, 2023. If you have never taken a university-level course in probability and statistics, you should follow the MOOC's offered by the mathematics faculty.
+
+The mathematics faculty at TU Delft will also have six MOOC's available on EdX by July 4, 2023 (links will be provided when the courses are available):
+
+- Calculus I (one variable)
+- Calculus II
+- Linear Algebra part I
+- Linear Algebra part II
+- Probability
+- Statistics
+
 [^1]: This is an experimental Jupyter Book, part of an educational research project, made by staff and MSc students of TU Delft. The first three columns with required prior knowledge were defined by the admission committee Civil Engineering. The final column with Open Educational Resources (OER) is experimental. This OER materials are provided as a service. Although we did our best to collect OER that reflect the required knowledge as good as possible, based on surveys among students and discussion with staff members, unfortunately we can not give a guarantee that the quality of all material is good. Suggestions are welcome via [email](mailto:h.r.schipper@tudelft.nl?subject=pre-for-cem-suggestions)


### PR DESCRIPTION
@RoelSchipper i added a short set of notes on the mathematics page to give information about CEG and EWI online courses. Let me know if you need me to make changes. Otherwise, I leave some notes about the git workflow for you to see how it worked.

- create branch `add-prob` on my computer
- commit changes (1 commit)
- push commit on branch to remote repo (github)
- on github, make pull request to merge `add-prob` into `main`
- once pull request is approved the pipeline takes care of the rest (Actions)

When you get some free time I can drop by your office and we can go through it later.